### PR TITLE
Fixed typographical error, changed admitedly to admittedly in README.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,7 @@ app.listen();
 ```
 
 This tells omega to serve the `./static` folder statically at the url `/static/*`, and then starts listening for incomming
-connections. Admitedly, this isn't the most exciting application in the world, but it illustrates the basics of omega;
+connections. Admittedly, this isn't the most exciting application in the world, but it illustrates the basics of omega;
 first and foremost: _omega is simple_. It tries to make whatever you're doing as straightforward as possible, and hide
 any complexity from you.
 


### PR DESCRIPTION
@Morgul, I've corrected a typographical error in the documentation of the [omega](https://github.com/Morgul/omega) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
